### PR TITLE
bug fix: add and remove bookmark functions modified to work correctly

### DIFF
--- a/src/backend/controllers/UserController.js
+++ b/src/backend/controllers/UserController.js
@@ -61,9 +61,7 @@ export const editUserHandler = function (schema, request) {
         404,
         {},
         {
-          errors: [
-            "Username cannot be changed",
-          ],
+          errors: ["Username cannot be changed"],
         }
       );
     }
@@ -134,7 +132,7 @@ export const bookmarkPostHandler = function (schema, request) {
       );
     }
     const isBookmarked = user.bookmarks.some(
-      (currPost) => currPost._id === postId
+      (currPostId) => currPostId === postId
     );
     if (isBookmarked) {
       return new Response(
@@ -143,7 +141,7 @@ export const bookmarkPostHandler = function (schema, request) {
         { errors: ["This Post is already bookmarked"] }
       );
     }
-    user.bookmarks.push(post);
+    user.bookmarks.push(post._id);
     this.db.users.update(
       { _id: user._id },
       { ...user, updatedAt: formatDate() }
@@ -181,13 +179,13 @@ export const removePostFromBookmarkHandler = function (schema, request) {
       );
     }
     const isBookmarked = user.bookmarks.some(
-      (currPost) => currPost._id === postId
+      (currPostId) => currPostId === postId
     );
     if (!isBookmarked) {
       return new Response(400, {}, { errors: ["Post not bookmarked yet"] });
     }
     const filteredBookmarks = user.bookmarks.filter(
-      (currPost) => currPost._id !== postId
+      (currPostId) => currPostId !== postId
     );
     user = { ...user, bookmarks: filteredBookmarks };
     this.db.users.update(
@@ -233,9 +231,7 @@ export const followUserHandler = function (schema, request) {
         404,
         {},
         {
-          errors: [
-            "You cannot follow yourself"
-          ],
+          errors: ["You cannot follow yourself"],
         }
       );
     }

--- a/src/backend/db/users.js
+++ b/src/backend/db/users.js
@@ -14,5 +14,6 @@ export const users = [
     password: "adarshBalika123",
     createdAt: formatDate(),
     updatedAt: formatDate(),
+    bookmarks: []
   },
 ];


### PR DESCRIPTION
**Error:**
There's error that occurred with the previous function in a particular scenario -
when the user tries to simultaneously like a post and also add it to bookmark. It resulted in a cyclical error. 

**More accurate description of behavior resulting in error :**  if user tries to like a post that is already bookmarked or vice a versa it gives error as below, even though both liking a post and adding to bookmark are working fine independently.

![image](https://github.com/HeyNitin/social-media-mockbee-template/assets/90078330/18454bf0-581c-415e-8f76-cce866b68d16)

**Why it must be like this?**
![image](https://github.com/HeyNitin/social-media-mockbee-template/assets/90078330/63ef1261-96d9-4c45-89fa-86cc5345413e)

**This PR resolves this error by modifying the following files**

**Idea addressed:**  Instead of storing the whole post in the bookmarks array we are just storing its id and hence breaking the cycle

1. users.js in `db` folder has additional key of bookmarks.  
2. code replaced for the `bookmarkPostHandler` and `removePostFromBookmarkHandler` functions. 

-----------
**Bookmark test -- console.log results **

![bookmarkresult](https://github.com/HeyNitin/social-media-mockbee-template/assets/90078330/6250d48d-820d-4b90-995e-55c5dcaedac7)

-----------

**Like and book mark for single post -- console.log results:** 

![likebookmark](https://github.com/HeyNitin/social-media-mockbee-template/assets/90078330/514fd02a-2f6f-47ff-8c05-ef8773180564)

Code added can be viewed here: https://gist.github.com/swapnilbawane/21a1f6e96ec526eea5494a22b2ec912e



